### PR TITLE
Wrong package name in `mapping` docs

### DIFF
--- a/docs/mapping/index.md
+++ b/docs/mapping/index.md
@@ -7,7 +7,7 @@ Import into your project to use it.
 
 ```java
 dependencies {
-    implementation("de.chojo.sadu", "sadu-mapping", "<version>")
+    implementation("de.chojo.sadu", "sadu-mapper", "<version>")
 }
 ```
 


### PR DESCRIPTION
According to the docs the package name of the mapping is "sadu-mapping"
But actually it is "sadu-mapper" so I fixed it.